### PR TITLE
Megi kernel likes the -pinephone suffix

### DIFF
--- a/rpm/realtek-bt-firmware.spec
+++ b/rpm/realtek-bt-firmware.spec
@@ -27,6 +27,7 @@ ls -lR .
 mkdir -p $RPM_BUILD_ROOT/lib/firmware/rtl_bt/
 cp %{SOURCE1} $RPM_BUILD_ROOT/lib/firmware/rtl_bt/
 cp %{SOURCE2} $RPM_BUILD_ROOT/lib/firmware/rtl_bt/
+ln -s /lib/firmware/rtl_bt/%{SOURCE2} $RPM_BUILD_ROOT/lib/firmware/rtl_bt/rtl8723cs_xx_config-pinephone.bin
 cp %{SOURCE3} $RPM_BUILD_ROOT/lib/firmware/rtl_bt/
 
 %files


### PR DESCRIPTION
I actually copied on my device but I guess symlinking should also work and save 63kb